### PR TITLE
fix(table): cell loads component on value difference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - `package.json` added meta data
 
+## [1.0.2] - 2018-09-03
+### Changed
+- 'Table Cell regenerates component on value changes'
+
 ## [1.0.1] - 2018-07-02
 ### Changed
 - `postbuild` script, fix for copy meta files.

--- a/packages/table/src/lib/table/components/table-cell/table-cell.component.ts
+++ b/packages/table/src/lib/table/components/table-cell/table-cell.component.ts
@@ -5,7 +5,8 @@ import {
 	OnChanges,
 	Type,
 	ViewContainerRef,
-	ChangeDetectorRef
+	ChangeDetectorRef,
+	SimpleChanges
 } from '@angular/core';
 import { Cell } from '../../types/table.types';
 
@@ -23,8 +24,12 @@ export class TableCellComponent implements OnChanges {
 		private changeDetectionRef: ChangeDetectorRef
 	) { }
 
-	public ngOnChanges() {
-		if (this.component) {
+	public ngOnChanges(changes: SimpleChanges) {
+		if (!changes.component) {
+			return;
+		}
+
+		if (changes.component.currentValue !== changes.component.previousValue) {
 			this.loadComponent();
 		}
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: [Contributing guidelines](https://github.com/FabianMeul/acpaas-ui-ngx/blob/master/.github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] angular.io application / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behaviour?
The cell creates a new instance of the component each time something changes, making stateful components useless

Issue Number: #18 

## What is the new behaviour?
The cell creates a new instance of the component if the component changes, making stateful components functional,

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


## Resolved issues
Closes: #18 
Fixes: #18 
Resolves: #18 