### PR TITLE
Replaced `BrowserModule` with `CommonModule` in the ngx-navigation-me…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 
+## Fixed
+- Replaced `BrowserModule` with `CommonModule` in the ngx-navigation-menu component. Importing the `BrowserModule` throws an error when working with lazy-loaded modules. Packages should always make use of `CommonModule` instead.
 
 ## [4.2.1] - 2020-06-10
 

--- a/packages/ngx-navigation-menu/src/lib/navigation-menu.module.ts
+++ b/packages/ngx-navigation-menu/src/lib/navigation-menu.module.ts
@@ -1,11 +1,11 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 import {MenuService} from './services/menu.service';
 import {Menu} from './interfaces';
-import {BrowserModule} from '@angular/platform-browser';
 import {RouterModule} from '@angular/router';
 import {COMPONENTS} from './components/components';
 import {AuiModule} from './aui/aui.module';
 import {LocalstorageService} from './services/localstorage.service';
+import {CommonModule} from "@angular/common";
 
 const defaultConfiguration: Menu.ModuleConfiguration = {
   dockedByDefault: false,
@@ -14,7 +14,7 @@ const defaultConfiguration: Menu.ModuleConfiguration = {
 
 @NgModule({
   imports: [
-    BrowserModule,
+    CommonModule,
     RouterModule,
     AuiModule,
   ],

--- a/packages/ngx-navigation-menu/src/lib/navigation-menu.module.ts
+++ b/packages/ngx-navigation-menu/src/lib/navigation-menu.module.ts
@@ -5,7 +5,7 @@ import {RouterModule} from '@angular/router';
 import {COMPONENTS} from './components/components';
 import {AuiModule} from './aui/aui.module';
 import {LocalstorageService} from './services/localstorage.service';
-import {CommonModule} from "@angular/common";
+import {CommonModule} from '@angular/common';
 
 const defaultConfiguration: Menu.ModuleConfiguration = {
   dockedByDefault: false,


### PR DESCRIPTION
ngx-navigation-menu

## PR Checklist

This PR fulfills the following requirements:
<!-- Please put "[x]" for requirements that this PR satisfies. -->

- [x] The commit message follows our guidelines: [Contributing guidelines](https://github.com/digipolisantwerp/acpaas-ui_angular/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] A [changelog entry](https://github.com/digipolisantwerp/acpaas-ui_angular/blob/master/guidelines/CHANGELOG.md) was added

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
It is not possible to use the ngx-navigation-menu component inside a lazy-loaded module because it imports `BrowserModule`

Issue Number: N/A

## What is the new behavior?
It doesn't import `BrowserModule` but instead imports `CommonModule` which it should do following the [Angular Docs](https://angular.io/guide/frequent-ngmodules#browsermodule-and-commonmodule).


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

## Resolved issues

<!--
See https://help.github.com/articles/closing-issues-using-keywords/ for more info
Closes: #123
Fixes: #123
Resolves: #123
-->